### PR TITLE
Add warning for the match.playersInfo event

### DIFF
--- a/docs/api/overwolf-games-events-heartstone.md
+++ b/docs/api/overwolf-games-events-heartstone.md
@@ -154,6 +154,8 @@ key               | Category    | Values                    | Notes             
 localPlayer | playersInfo   |  See [notes](#localPlayer-note) |     |   123.0 |
 opponent | playersInfo   |  See [notes](#opponent-note) |     |   123.0 |
 
+Please note: the information is only sent when it changed since last time the event was emitted. It is **not** sent systematically at the beginning of each match, so if you want to use the information for each match, you should cache it.
+
 #### *localPlayer* note
 
 * "<b>name</b>" – name of local player


### PR DESCRIPTION
Add a note that the info is only fired if it changed since the last time. I've spent a few hours trying to understand why in some cases I have the full playersInfo at the beginning of a match, why sometimes I only had the opponent's, and why sometimes I had nothing :)