### PR TITLE
Correct AutoChess ID

### DIFF
--- a/docs/api/overwolf-games-events-autochess.md
+++ b/docs/api/overwolf-games-events-autochess.md
@@ -9,7 +9,7 @@ sidebar_label: Auto Chess
 Please read the [overwolf.games.events](overwolf-games-events) documentation page to learn how to use Overwolf game events.
 
 :::important Game ID
-7314
+21600
 :::
 
 ## Sample Apps


### PR DESCRIPTION
The GameFiles xml doc suggests the game id should be `21600` as DOTA 2 uses `7314`, however https://game-events-status.overwolf.com/21600_prod.json does not resolve. That needs checking from your side please.