### PR TITLE
ID definition in GameInfo

### DIFF
--- a/docs/api/overwolf-games.md
+++ b/docs/api/overwolf-games.md
@@ -299,7 +299,7 @@ Contains information about a game.
 | isRunning          | bool     | Returns whether the game is currently running                                                       | 0.78  |
 | allowsVideoCapture | bool     | Returns whether the game allows video to be captured                                                | 0.78  |
 | title              | string   | Returns the title of the game                                                                       | 0.78  |
-| id                 | int      | Returns the ID of the game                                                                          | 0.78  |
+| id                 | int      | Returns the game ID concatenated with the Instance ID of the game. Divide it by 10 to get the game ID                                                                           | 0.78  |
 | width              | int      | Returns the pixel width of the game window                                                          | 0.78  |
 | height             | int      | Returns the pixel height of the game window                                                         | 0.78  |
 | logicalWidth       | int      | Returns the game-reported (logical) pixel width of the game window                                  | 0.78  |


### PR DESCRIPTION
The returned ID is in fact Game ID + Instance ID, previous description was misleading.