### PR TITLE
Add passthrough variable to example

### DIFF
--- a/docs/topics/using-tab.md
+++ b/docs/topics/using-tab.md
@@ -52,6 +52,7 @@ In order to implement a hotkey which works with an OnHold Tab functionality, we 
         "title": "Show Player",
         "action-type": "custom",
         "default": "Shift+F9",
+        "passthrough": true,
         "hold": true
     }
 }


### PR DESCRIPTION
Given the whole concept of this page is to “ride the Tab key”, I would strongly suggest you change this example to include the passthrough variable.