### PR TITLE
Added note regarding analytics.js vs gtag.js

### DIFF
--- a/docs/topics/app-analytics.md
+++ b/docs/topics/app-analytics.md
@@ -12,6 +12,10 @@ Please take the time you need to implement any chosen analytics service thorough
 
 ## Google Analytics: Basic Implementation
 
+:::warning
+The below information is regarding the implementation of Google Analytics' **"analytics.js"**. The newer, more up-to-date implementation of **"gtag.js"** _does not work_ in Overwolf apps at the moment. Keep this in mind when searching for implementation documentation elsewhere.
+:::
+
 ### Update your manifest.json
 
 Open up the external connections necessary for communicating with the Google service:

--- a/docs/topics/app-analytics.md
+++ b/docs/topics/app-analytics.md
@@ -12,7 +12,7 @@ Please take the time you need to implement any chosen analytics service thorough
 
 ## Google Analytics: Basic Implementation
 
-:::warning
+:::tip note
 The below information is regarding the implementation of Google Analytics' **"analytics.js"**. The newer, more up-to-date implementation of **"gtag.js"** _does not work_ in Overwolf apps at the moment. Keep this in mind when searching for implementation documentation elsewhere.
 :::
 


### PR DESCRIPTION
Perhaps it’s valuable to update this to use the new gtag.js from Google Analytics, as analytics.js is now over 10 years old.

Or at least add this note stating that currently implementing gtag.js does not work within an Overwolf app, so you need to use analytics.js.