### PR TITLE
Newcomer Playlist gamemode discrete name

### DIFF
--- a/docs/api/overwolf-games-events-rainbow-six.md
+++ b/docs/api/overwolf-games-events-rainbow-six.md
@@ -87,7 +87,7 @@ The `game_mode` returns on this format:
 While the possible values are:
 
 * No mode was selected: `NONE`
-* Multiplayer > Newcomer: `MATCHMAKING_PVP`
+* Multiplayer > Newcomer: `MATCHMAKING_PVP_NEWCOMER`
 * Multiplayer > Quick Match: `MATCHMAKING_PVP`
 * Multiplayer > Special Event: `MATCHMAKING_PVP_EVENT`
 * Multiplayer > Arcade Playlist: `MATCHMAKING_PVP_EVENT`


### PR DESCRIPTION
Just noticed that the Newcomer Playlist gamemode now has a discrete name, to differentiate it from Quick Match