### PR TITLE
Broken link

### DIFF
--- a/docs/status/world-of-warships.md
+++ b/docs/status/world-of-warships.md
@@ -17,6 +17,6 @@ sidebar_label: World of Warships
 <script src="/js/games_metadata.js"></script>
 
 <div id="gameEventsStatus">
-  <script> const GameID = 10746; const DocsLink = "../api/overwolf-games-events-wow";</script>
+  <script> const GameID = 10746; const DocsLink = "../api/overwolf-games-events-wows";</script>
   <script type="text/jsx" src="/jsx/specificGameEventsStatus.jsx"></script>
 </div>


### PR DESCRIPTION
The `Go to the API docs page`-link linked to World of Warcraft instead of World of Warships.
`../api/overwolf-games-events-wow` vs. `../api/overwolf-games-events-wows`