### PR TITLE
fix: Removed Game Summary-extension from link

### DIFF
--- a/docs/download/download-overview.md
+++ b/docs/download/download-overview.md
@@ -14,12 +14,12 @@ To develop, load or run unpacked or unreleased apps, you have to [whitelist](../
 
 ## Developers Version
 
-* Download the [Latest Overwolf Developers Client](https://download.overwolf.com/install/Download?Name=Game+Summary&ExtensionId=flkgdpkkjcoapbgmgpidhepajgkhckpgpibmlclb&Channel=Developers).
+* Download the [Latest Overwolf Developers Client](https://download.overwolf.com/install/Download?Channel=Developers).
 
 
 ## Public Version
 
-* Download the [Latest Overwolf Public Version](https://download.overwolf.com/install/Download?Name=Game+Summary&ExtensionId=flkgdpkkjcoapbgmgpidhepajgkhckpgpibmlclb&Channel=website).
+* Download the [Latest Overwolf Public Version](https://download.overwolf.com/install/Download?Channel=website).
 
 ## Sample App
 

--- a/docs/start/creating-demo-app.md
+++ b/docs/start/creating-demo-app.md
@@ -15,7 +15,7 @@ To learn how a real-world Overwolf apps should look like, continue to the [sampl
 ## Get the Overwolf client
 
 To build Overwolf apps, you first need to download the Overwolf client.
-You can find the latest version [Here](https://download.overwolf.com/install/Download?Name=Game+Summary&ExtensionId=flkgdpkkjcoapbgmgpidhepajgkhckpgpibmlclb&Channel=developers).
+You can find the latest version [Here](https://download.overwolf.com/install/Download?Channel=developers).
 
 ## Building a demo app from scratch
 

--- a/docs/start/sdk-introduction.md
+++ b/docs/start/sdk-introduction.md
@@ -25,7 +25,7 @@ However, full-blown desktop application solutions such as electron.js, AppJS and
 
 
 To build Overwolf apps, you need to download the Overwolf client.
-You can find the latest developer client version [Here](https://download.overwolf.com/install/Download?Name=Game+Summary&ExtensionId=flkgdpkkjcoapbgmgpidhepajgkhckpgpibmlclb&Channel=developers).
+You can find the latest developer client version [Here](https://download.overwolf.com/install/Download?Channel=developers).
 
 ### Manifest file
 


### PR DESCRIPTION
The installer will no longer bundle with Game Summary