### PR TITLE
Fixed typo on Process Manager Plugin

### DIFF
--- a/docs/topics/process-manager-plugin.md
+++ b/docs/topics/process-manager-plugin.md
@@ -16,7 +16,7 @@ You can read the full list of functions and events available in the Process Mana
 
 * You can download the plugin from our [GitHub repository](https://github.com/overwolf/overwolf-plugins/tree/master/sample_apps/process_manager).
 * A sample Overwolf app using the Process Manager plugin can be found [here](https://github.com/overwolf/overwolf-plugins/tree/master/sample_apps/process_manager).  
-  This app runs notepad.exe once the Overwold app is launched.
+  This app runs notepad.exe once the Overwolf app is launched.
 * Note that the DLL file is placed inside of the app’s directory – so if you recompile it, you’ll need to replace the old DLL with the new one inside the folder. Please review the manifest.json file to view how to reference the Plugin file.
 * All DLLs should be compiled for the x64 platform.
 


### PR DESCRIPTION
There were a typo on line 19 (Overwold -> Overwolf)