### PR TITLE
Update update-store-listing.md

### DIFF
--- a/docs/topics/update-store-listing.md
+++ b/docs/topics/update-store-listing.md
@@ -16,7 +16,7 @@ Changes submitted will take up to ~30min to process and go live.
 
 ## Login to the developers console
 
-After logging to the [Overwolf developers console](#https://console.overwolf.com/), navigate to Store Listing:
+After logging to the [Overwolf developers console](https://console.overwolf.com/), navigate to Store Listing:
 
 ![login](../assets/dev-console/update-store/login.png)
 


### PR DESCRIPTION
Fixing link to dev console.
Right now it's redirecting to : https://overwolf.github.io/docs/topics/update-store-listing#https://console.overwolf.com/