### PR TITLE
docs: adds valorant new agent astra

### DIFF
--- a/docs/api/overwolf-games-events-valorant.md
+++ b/docs/api/overwolf-games-events-valorant.md
@@ -106,6 +106,7 @@ Possible agent values:
 * "Killjoy_PC_C" = Killjoy
 * "Guide_PC_C" = Skye
 * "Stealth_PC_C" = Yoru
+* "Rift_PC_C" = Astra
 
 ## `match_info`
 


### PR DESCRIPTION
Adds new agent to the docs under **possible agent values**:
https://overwolf.github.io/docs/api/overwolf-games-events-valorant
