### PR TITLE
Suggestions for 3. Check Whether User is Subscribed

### DIFF
--- a/docs/start/subscriptions-integration.md
+++ b/docs/start/subscriptions-integration.md
@@ -72,6 +72,14 @@ overwolf.profile.subscriptions.getActivePlans(function(info) {
     }
 );
 ```
+--Suggested Changes from Dev(the if statements above caused issues for LeagueTracker app)--
+
+overwolf.profile.subscriptions.getActivePlans(function(info) { 
+    if (info.success && info.plans != null && info.plans.includes(myPlanID)) {    
+            isSubscribed = true;
+            removeAds();
+    }
+);
 
 ## 4. Monitor Subscription Changes
 


### PR DESCRIPTION
The Developer of League Tracker suggested only using one if statement claiming that the two if statements given in the sample was causing problems for him.