### PR TITLE
update api doc

### DIFF
--- a/docs/api/overwolf-games-events-hearthstone.md
+++ b/docs/api/overwolf-games-events-hearthstone.md
@@ -31,7 +31,7 @@ It is highly recommended to communicate errors and warnings to your app users. C
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 gep_internal | gep_internal| Local + Public version number|See [notes](#gep_internal-note)|   143.0       |
 
 #### *gep_internal* note
@@ -54,7 +54,7 @@ collection        | game_info   | Current card collection of the local player. S
 
 * The “collection”  data is available as soon as the player logs into Hearthstone.
 * The collection is updated whenever the user adds/removes a card.
-  
+
 Example for cards "collection":
 
 ```json
@@ -71,7 +71,7 @@ Example for cards "collection":
 
 `{
   "id" : "card_id" ,
-  "count" : "int" , 
+  "count" : "int" ,
   "premiumCount" : "int"
 }  `
 
@@ -111,38 +111,55 @@ Can be one of the following:
 
 key               | Category    | Values                    | Notes                 | Since GEP Ver. |
 ----------------- | ------------| ------------------------- | --------------------- | ------------- |
-deck_id           | decks       |  The “decks” feature provides data about the currently “visible” decks. | See [notes](#deck_id-note)    |   119.1 |
+[deck_id]           | decks       |  The “decks” feature provides data about the currently “visible” decks. | See [notes](#deck_id-note)    |   119.1 |
 selected_deck     | selected_deck | The selected deck.  |  See [notes](#selected_deck-note)   |   119.1 |
-Adventure Deck     | decks | The currently played deck on adventure mode.  |  See [notes](#Adventure Deck-note)   |   143.0 |
+Adventure Deck     | decks | The currently played deck on adventure mode.  |  See [notes](#Adventure-Deck-note)   |   143.0 |
 adventure_loot_options | decks | The currently offered 3-option draft (between bosses)  |  See [notes](#adventure_loot_options-note)   |   143.0 |
 
 #### *deck_id* note
 
+The key is the deck's `deck_id` string. It is not the literal string "deck_id". See example below.
+
 Decks are “visible” when the local player starts a new game, during the “deck selection” screen, or when the local player enters the “My Collection” menu. The following data is being provided for each deck:
 * Deck name / id
 * Deck cards (array of cards)
+* Deck key
 
 “Card” structure:
 
 `{
-  "id" : "card_id" ,
-  "count" : "int" , 
+  "id" : "card_id",
+  "count" : "int",
   "premiumCount" : "int"
 }  `
 * “id” – The [card's id](http://metastats.net/allcards/)
 * “count” – The number of regular cards
 * “premiumCount” – The number of premium (golden) cards
 
-Example for a “deck” info-update structure:
+Example for a “deck_id” info-update structure:
 
-`{"feature":"decks","category":"decks","key":"Basic Shaman",
-"value":"{"deck_id":"Basic Shaman",
-"cards":[{"id":"CS1_042","count":"1","premiumCount":"0"},
-{"id":"CS2_103","count":"1","premiumCount":"0"},
-...
-{"id":"LOOT_413","count":"2","premiumCount":"0"},
-{"id":"UNG_923","count":"1","premiumCount":"0"}],
-"deck_key":"deck_0"}"} `
+```json
+{
+  "info":{
+    "decks":{
+      "Mage":"{
+        \"deck_id\":\"Mage\",
+          \"cards\":[
+            {\"id\":\"BOT_573\",\"count\":1,\"premiumCount\":0},
+            {\"id\":\"CS2_024\",\"count\":2,\"premiumCount\":0},
+            {\"id\":\"CS2_033\",\"count\":1,\"premiumCount\":0},
+            ...
+            {\"id\":\"UNG_845\",\"count\":1,\"premiumCount\":0},
+            {\"id\":\"UNG_941\",\"count\":1,\"premiumCount\":0}
+          ],
+        \"deck_key\":\"adventure_deck\"
+      }"
+    }
+  },
+  "feature":"decks"
+}
+
+```
 
 <b>Arena Decks</b>
 
@@ -166,9 +183,9 @@ Example for a “selected deck” structure:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "decks":{ 
+{
+   "info":{
+      "decks":{
          "Adventure Deck":"{
                             "deck_id":"Adventure Deck",
                             "cards":[
@@ -192,9 +209,9 @@ Data Example:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "decks":{ 
+{
+   "info":{
+      "decks":{
                "adventure_loot_options":"[
                                           {"deck_id":"option_a","cards":[
                                                                          {"id":"EX1_279","count":1,"premiumCount":0},
@@ -291,9 +308,9 @@ Data Example:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "match_info":{ 
+{
+   "info":{
+      "match_info":{
          "adventure_stats":"{"adventure_trl":{
          "dungeon_crawl_all_classes_total_boss_wins":29,
          "dungeon_crawl_all_classes_total_run_wins":1,
@@ -373,4 +390,3 @@ Data Example:
 ```json
 {"info":{"match_info":{"pseudo_match_id":"5a7e3729-993c-414d-8e3f-592faeef81e7"}},"feature":"match_info"}
 ```
-

--- a/docs/api/overwolf-games-events-lol.md
+++ b/docs/api/overwolf-games-events-lol.md
@@ -49,7 +49,7 @@ It's highly recommended to communicate errors and warnings to your app users. Ch
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 gep_internal | gep_internal| Local + Public version number|See [notes](#gep_internal-note)|   143.0       |
 
 #### *gep_internal* note
@@ -65,7 +65,7 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 active_player | live_client_data | In-game data received by the client. |See [notes](#active_player-note)|   143.1    |
 all_players | live_client_data | In-game data received by the client. |See [notes](#all_players-note)|   143.1   |
 events | live_client_data | In-game data received by the client. |See [notes](#events-note)|   143.1  |
@@ -84,170 +84,141 @@ port | live_client_data | In-game data received by the client. |See [notes](#por
 {
   "info": {
     "live_client_data": {
-      "active_player": "{"
-      abilities ":{"
-      E ":{"
-      abilityLevel ":0,"
-      displayName ":"
-      Stacked Deck ","
-      id ":"
-      CardmasterStack ","
-      rawDescription ":"
-      GeneratedTip_Spell_CardmasterStack_Description ","
-      rawDisplayName ":"
-      GeneratedTip_Spell_CardmasterStack_DisplayName "},"
-      Passive ":{"
-      displayName ":"
-      Loaded Dice ","
-      id ":"
-      SecondSight ","
-      rawDescription ":"
-      GeneratedTip_Passive_SecondSight_Description ","
-      rawDisplayName ":"
-      GeneratedTip_Passive_SecondSight_DisplayName "},"
-      Q ":{"
-      abilityLevel ":0,"
-      displayName ":"
-      Wild Cards ","
-      id ":"
-      WildCards ","
-      rawDescription ":"
-      GeneratedTip_Spell_WildCards_Description ","
-      rawDisplayName ":"
-      GeneratedTip_Spell_WildCards_DisplayName "},"
-      R ":{"
-      abilityLevel ":0,"
-      displayName ":"
-      Destiny ","
-      id ":"
-      Destiny ","
-      rawDescription ":"
-      GeneratedTip_Spell_Destiny_Description ","
-      rawDisplayName ":"
-      GeneratedTip_Spell_Destiny_DisplayName "},"
-      W ":{"
-      abilityLevel ":0,"
-      displayName ":"
-      Pick a Card ","
-      id ":"
-      PickACard ","
-      rawDescription ":"
-      GeneratedTip_Spell_PickACard_Description ","
-      rawDisplayName ":"
-      GeneratedTip_Spell_PickACard_DisplayName "}},"
-      championStats ":{"
-      abilityHaste ":0,"
-      abilityPower ":0,"
-      armor ":21,"
-      armorPenetrationFlat ":0,"
-      armorPenetrationPercent ":1,"
-      attackDamage ":25,"
-      attackRange ":0,"
-      attackSpeed ":0.6510000228881836,"
-      bonusArmorPenetrationPercent ":1,"
-      bonusMagicPenetrationPercent ":1,"
-      cooldownReduction ":0,"
-      critChance ":0,"
-      critDamage ":0,"
-      currentHealth ":534,"
-      healthRegenRate ":0,"
-      lifeSteal ":0,"
-      magicLethality ":0,"
-      magicPenetrationFlat ":0,"
-      magicPenetrationPercent ":1,"
-      magicResist ":30,"
-      maxHealth ":534,"
-      moveSpeed ":330,"
-      physicalLethality ":0,"
-      resourceMax ":333,"
-      resourceRegenRate ":0,"
-      resourceType ":"
-      MANA ","
-      resourceValue ":333,"
-      spellVamp ":0,"
-      tenacity ":0},"
-      currentGold ":0,"
-      fullRunes ":{"
-      generalRunes ":[{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},{"
-      displayName ":"
-      Taste of Blood ","
-      id ":8139,"
-      rawDescription ":"
-      perk_tooltip_TasteOfBlood ","
-      rawDisplayName ":"
-      perk_displayname_TasteOfBlood "},{"
-      displayName ":"
-      Eyeball Collection ","
-      id ":8138,"
-      rawDescription ":"
-      perk_tooltip_EyeballCollection ","
-      rawDisplayName ":"
-      perk_displayname_EyeballCollection "},{"
-      displayName ":"
-      Ravenous Hunter ","
-      id ":8135,"
-      rawDescription ":"
-      perk_tooltip_RavenousHunter ","
-      rawDisplayName ":"
-      perk_displayname_RavenousHunter "},{"
-      displayName ":"
-      Presence of Mind ","
-      id ":8009,"
-      rawDescription ":"
-      perk_tooltip_PresenceOfMind ","
-      rawDisplayName ":"
-      perk_displayname_PresenceOfMind "},{"
-      displayName ":"
-      Coup de Grace ","
-      id ":8014,"
-      rawDescription ":"
-      perk_tooltip_CoupDeGrace ","
-      rawDisplayName ":"
-      perk_displayname_CoupDeGrace "}],"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "},"
-      statRunes ":[{"
-      id ":5008,"
-      rawDescription ":"
-      perk_tooltip_StatModAdaptive "},{"
-      id ":5008,"
-      rawDescription ":"
-      perk_tooltip_StatModAdaptive "},{"
-      id ":5003,"
-      rawDescription ":"
-      perk_tooltip_StatModMagicResist "}]},"
-      level ":1,"
-      summonerName ":"
-      Sh4rgaas "}"
+      "active_player": {
+        "abilities": {
+          "E": {
+            "abilityLevel": 0,
+            "displayName": "Stacked Deck",
+            "id": "CardmasterStack",
+            "rawDescription": "GeneratedTip_Spell_CardmasterStack_Description",
+            "rawDisplayName": "GeneratedTip_Spell_CardmasterStack_DisplayName"
+          },
+          "Passive": {
+            "displayName": "Loaded Dice",
+            "id": "SecondSight",
+            "rawDescription": "GeneratedTip_Passive_SecondSight_Description",
+            "rawDisplayName": "GeneratedTip_Passive_SecondSight_DisplayName"
+          },
+          "Q": {
+            "abilityLevel": 0,
+            "displayName": "Wild Cards",
+            "id": "WildCards",
+            "rawDescription": "GeneratedTip_Spell_WildCards_Description",
+            "rawDisplayName": "GeneratedTip_Spell_WildCards_DisplayName"
+          },
+          "R": {
+            "abilityLevel": 0,
+            "displayName": "Destiny",
+            "id": "Destiny",
+            "rawDescription": "GeneratedTip_Spell_Destiny_Description",
+            "rawDisplayName": "GeneratedTip_Spell_Destiny_DisplayName"
+          },
+          "W": {
+            "abilityLevel": 0,
+            "displayName": "Pick a Card",
+            "id": "PickACard",
+            "rawDescription": "GeneratedTip_Spell_PickACard_Description",
+            "rawDisplayName": "GeneratedTip_Spell_PickACard_DisplayName"
+          }
+        },
+        "championStats": {
+          "abilityHaste": 0,
+          "abilityPower": 0,
+          "armor": 21,
+          "armorPenetrationFlat": 0,
+          "armorPenetrationPercent": 1,
+          "attackDamage": 25,
+          "attackRange": 0,
+          "attackSpeed": 0.6510000228881836,
+          "bonusArmorPenetrationPercent": 1,
+          "bonusMagicPenetrationPercent": 1,
+          "cooldownReduction": 0,
+          "critChance": 0,
+          "critDamage": 0,
+          "currentHealth": 534,
+          "healthRegenRate": 0,
+          "lifeSteal": 0,
+          "magicLethality": 0,
+          "magicPenetrationFlat": 0,
+          "magicPenetrationPercent": 1,
+          "magicResist": 30,
+          "maxHealth": 534,
+          "moveSpeed": 330,
+          "physicalLethality": 0,
+          "resourceMax": 333,
+          "resourceRegenRate": 0,
+          "resourceType": "MANA",
+          "resourceValue": 333,
+          "spellVamp": 0,
+          "tenacity": 0
+        },
+        "currentGold": 0,
+        "fullRunes": {
+          "generalRunes": [
+            {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            {
+              "displayName": "Taste of Blood",
+              "id": 8139,
+              "rawDescription": "perk_tooltip_TasteOfBlood",
+              "rawDisplayName": "perk_displayname_TasteOfBlood"
+            },
+            {
+              "displayName": "Eyeball Collection",
+              "id": 8138,
+              "rawDescription": "perk_tooltip_EyeballCollection",
+              "rawDisplayName": "perk_displayname_EyeballCollection"
+            },
+            {
+              "displayName": "Ravenous Hunter",
+              "id": 8135,
+              "rawDescription": "perk_tooltip_RavenousHunter",
+              "rawDisplayName": "perk_displayname_RavenousHunter"
+            },
+            {
+              "displayName": "Presence of Mind",
+              "id": 8009,
+              "rawDescription": "perk_tooltip_PresenceOfMind",
+              "rawDisplayName": "perk_displayname_PresenceOfMind"
+            },
+            {
+              "displayName": "Coup de Grace",
+              "id": 8014,
+              "rawDescription": "perk_tooltip_CoupDeGrace",
+              "rawDisplayName": "perk_displayname_CoupDeGrace"
+            }
+          ],
+          "keystone": {
+            "displayName": "Dark Harvest",
+            "id": 8128,
+            "rawDescription": "perk_tooltip_DarkHarvest",
+            "rawDisplayName": "perk_displayname_DarkHarvest"
+          },
+          "primaryRuneTree": {
+            "displayName": "Domination",
+            "id": 8100,
+            "rawDescription": "perkstyle_tooltip_7200",
+            "rawDisplayName": "perkstyle_displayname_7200"
+          },
+          "secondaryRuneTree": {
+            "displayName": "Precision",
+            "id": 8000,
+            "rawDescription": "perkstyle_tooltip_7201",
+            "rawDisplayName": "perkstyle_displayname_7201"
+          },
+          "statRunes": [
+            { "id": 5008, "rawDescription": "perk_tooltip_StatModAdaptive" },
+            { "id": 5008, "rawDescription": "perk_tooltip_StatModAdaptive" },
+            { "id": 5003, "rawDescription": "perk_tooltip_StatModMagicResist" }
+          ]
+        },
+        "level": 1,
+        "summonerName": "Sh4rgaas"
+      }
     }
   },
   "feature": "live_client_data"
@@ -267,667 +238,554 @@ port | live_client_data | In-game data received by the client. |See [notes](#por
 {
   "info": {
     "live_client_data": {
-      "all_players": "[{"
-      championName ":"
-      Twisted Fate ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[{"
-      canUse ":true,"
-      consumable ":true,"
-      count ":1,"
-      displayName ":"
-      Poro - Snax ","
-      itemID ":2052,"
-      price ":0,"
-      rawDescription ":"
-      game_item_description_2052 ","
-      rawDisplayName ":"
-      game_item_displayname_2052 ","
-      slot ":6}],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_TwistedFate ","
-      rawSkinName ":"
-      game_character_skin_displayname_TwistedFate_9 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":9,"
-      skinName ":"
-      Cutpurse Twisted Fate ","
-      summonerName ":"
-      Sh4rgaas ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Ghost ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerHaste_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerHaste_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "}},"
-      team ":"
-      CHAOS "},{"
-      championName ":"
-      Brand ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Brand ","
-      rawSkinName ":"
-      game_character_skin_displayname_Brand_2 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":2,"
-      skinName ":"
-      Vandal Brand ","
-      summonerName ":"
-      Gordon xD ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Heal ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerHeal_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerHeal_DisplayName "}},"
-      team ":"
-      ORDER "},{"
-      championName ":"
-      Gragas ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Gragas ","
-      rawSkinName ":"
-      game_character_skin_displayname_Gragas_10 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":10,"
-      skinName ":"
-      Arctic Ops Gragas ","
-      summonerName ":"
-      IM Piotrovic ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Ignite ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerDot_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerDot_DisplayName "}},"
-      team ":"
-      ORDER "},{"
-      championName ":"
-      Shen ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Shen ","
-      rawSkinName ":"
-      game_character_skin_displayname_Shen_6 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Hail of Blades ","
-      id ":9923,"
-      rawDescription ":"
-      perk_tooltip_HailOfBlades ","
-      rawDisplayName ":"
-      perk_displayname_HailOfBlades "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":6,"
-      skinName ":"
-      TPA Shen ","
-      summonerName ":"
-      ToxicMolester ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Clarity ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerMana_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerMana_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "}},"
-      team ":"
-      ORDER "},{"
-      championName ":"
-      Vayne ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Vayne ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Hail of Blades ","
-      id ":9923,"
-      rawDescription ":"
-      perk_tooltip_HailOfBlades ","
-      rawDisplayName ":"
-      perk_displayname_HailOfBlades "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":0,"
-      summonerName ":"
-      ToxikBull ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Barrier ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName "}},"
-      team ":"
-      ORDER "},{"
-      championName ":"
-      Pantheon ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Pantheon ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Electrocute ","
-      id ":8112,"
-      rawDescription ":"
-      perk_tooltip_Electrocute ","
-      rawDisplayName ":"
-      perk_displayname_Electrocute "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":0,"
-      summonerName ":"
-      Haorn ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Mark ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName "}},"
-      team ":"
-      ORDER "},{"
-      championName ":"
-      Rell ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Rell ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Aftershock ","
-      id ":8439,"
-      rawDescription ":"
-      perk_tooltip_VeteranAftershock ","
-      rawDisplayName ":"
-      perk_displayname_VeteranAftershock "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Resolve ","
-      id ":8400,"
-      rawDescription ":"
-      perkstyle_tooltip_7204 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7204 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":0,"
-      summonerName ":"
-      Tαkumi Usui ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Mark ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName "}},"
-      team ":"
-      CHAOS "},{"
-      championName ":"
-      Anivia ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Anivia ","
-      rawSkinName ":"
-      game_character_skin_displayname_Anivia_8 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Sorcery ","
-      id ":8200,"
-      rawDescription ":"
-      perkstyle_tooltip_7202 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7202 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":8,"
-      skinName ":"
-      Papercraft Anivia ","
-      summonerName ":"
-      TheShackledCaps ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Barrier ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName "}},"
-      team ":"
-      CHAOS "},{"
-      championName ":"
-      Jhin ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Jhin ","
-      rawSkinName ":"
-      game_character_skin_displayname_Jhin_3 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Dark Harvest ","
-      id ":8128,"
-      rawDescription ":"
-      perk_tooltip_DarkHarvest ","
-      rawDisplayName ":"
-      perk_displayname_DarkHarvest "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Precision ","
-      id ":8000,"
-      rawDescription ":"
-      perkstyle_tooltip_7201 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7201 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":3,"
-      skinName ":"
-      SKT T1 Jhin ","
-      summonerName ":"
-      SzczodryMarynarz ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Barrier ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName "}},"
-      team ":"
-      CHAOS "},{"
-      championName ":"
-      Lissandra ","
-      isBot ":false,"
-      isDead ":false,"
-      items ":[],"
-      level ":1,"
-      position ":"
-      NONE ","
-      rawChampionName ":"
-      game_character_displayname_Lissandra ","
-      rawSkinName ":"
-      game_character_skin_displayname_Lissandra_3 ","
-      respawnTimer ":0,"
-      runes ":{"
-      keystone ":{"
-      displayName ":"
-      Electrocute ","
-      id ":8112,"
-      rawDescription ":"
-      perk_tooltip_Electrocute ","
-      rawDisplayName ":"
-      perk_displayname_Electrocute "},"
-      primaryRuneTree ":{"
-      displayName ":"
-      Domination ","
-      id ":8100,"
-      rawDescription ":"
-      perkstyle_tooltip_7200 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7200 "},"
-      secondaryRuneTree ":{"
-      displayName ":"
-      Sorcery ","
-      id ":8200,"
-      rawDescription ":"
-      perkstyle_tooltip_7202 ","
-      rawDisplayName ":"
-      perkstyle_displayname_7202 "}},"
-      scores ":{"
-      assists ":0,"
-      creepScore ":0,"
-      deaths ":0,"
-      kills ":0,"
-      wardScore ":0},"
-      skinID ":3,"
-      skinName ":"
-      Program Lissandra ","
-      summonerName ":"
-      JALLLAA ","
-      summonerSpells ":{"
-      summonerSpellOne ":{"
-      displayName ":"
-      Mark ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName "},"
-      summonerSpellTwo ":{"
-      displayName ":"
-      Flash ","
-      rawDescription ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_Description ","
-      rawDisplayName ":"
-      GeneratedTip_SummonerSpell_SummonerFlash_DisplayName "}},"
-      team ":"
-      CHAOS "}]"
+      "all_players": [
+        {
+          "championName": "Twisted Fate",
+          "isBot": false,
+          "isDead": false,
+          "items": [
+            {
+              "canUse": true,
+              "consumable": true,
+              "count": 1,
+              "displayName": "Poro - Snax",
+              "itemID": 2052,
+              "price": 0,
+              "rawDescription": "game_item_description_2052",
+              "rawDisplayName": "game_item_displayname_2052",
+              "slot": 6
+            }
+          ],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_TwistedFate",
+          "rawSkinName": "game_character_skin_displayname_TwistedFate_9",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 9,
+          "skinName": "Cutpurse Twisted Fate",
+          "summonerName": "Sh4rgaas",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Ghost",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerHaste_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerHaste_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            }
+          },
+          "team": "CHAOS"
+        },
+        {
+          "championName": "Brand",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Brand",
+          "rawSkinName": "game_character_skin_displayname_Brand_2",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 2,
+          "skinName": "Vandal Brand",
+          "summonerName": "Gordon xD",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Heal",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerHeal_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerHeal_DisplayName"
+            }
+          },
+          "team": "ORDER"
+        },
+        {
+          "championName": "Gragas",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Gragas",
+          "rawSkinName": "game_character_skin_displayname_Gragas_10",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 10,
+          "skinName": "Arctic Ops Gragas",
+          "summonerName": "IM Piotrovic",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Ignite",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerDot_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerDot_DisplayName"
+            }
+          },
+          "team": "ORDER"
+        },
+        {
+          "championName": "Shen",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Shen",
+          "rawSkinName": "game_character_skin_displayname_Shen_6",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Hail of Blades",
+              "id": 9923,
+              "rawDescription": "perk_tooltip_HailOfBlades",
+              "rawDisplayName": "perk_displayname_HailOfBlades"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 6,
+          "skinName": "TPA Shen",
+          "summonerName": "ToxicMolester",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Clarity",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerMana_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerMana_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            }
+          },
+          "team": "ORDER"
+        },
+        {
+          "championName": "Vayne",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Vayne",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Hail of Blades",
+              "id": 9923,
+              "rawDescription": "perk_tooltip_HailOfBlades",
+              "rawDisplayName": "perk_displayname_HailOfBlades"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 0,
+          "summonerName": "ToxikBull",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Barrier",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerBarrier_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName"
+            }
+          },
+          "team": "ORDER"
+        },
+        {
+          "championName": "Pantheon",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Pantheon",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Electrocute",
+              "id": 8112,
+              "rawDescription": "perk_tooltip_Electrocute",
+              "rawDisplayName": "perk_displayname_Electrocute"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 0,
+          "summonerName": "Haorn",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Mark",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerSnowball_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName"
+            }
+          },
+          "team": "ORDER"
+        },
+        {
+          "championName": "Rell",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Rell",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Aftershock",
+              "id": 8439,
+              "rawDescription": "perk_tooltip_VeteranAftershock",
+              "rawDisplayName": "perk_displayname_VeteranAftershock"
+            },
+            "primaryRuneTree": {
+              "displayName": "Resolve",
+              "id": 8400,
+              "rawDescription": "perkstyle_tooltip_7204",
+              "rawDisplayName": "perkstyle_displayname_7204"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 0,
+          "summonerName": "Tαkumi Usui",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Mark",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerSnowball_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName"
+            }
+          },
+          "team": "CHAOS"
+        },
+        {
+          "championName": "Anivia",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Anivia",
+          "rawSkinName": "game_character_skin_displayname_Anivia_8",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Sorcery",
+              "id": 8200,
+              "rawDescription": "perkstyle_tooltip_7202",
+              "rawDisplayName": "perkstyle_displayname_7202"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 8,
+          "skinName": "Papercraft Anivia",
+          "summonerName": "TheShackledCaps",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Barrier",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerBarrier_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName"
+            }
+          },
+          "team": "CHAOS"
+        },
+        {
+          "championName": "Jhin",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Jhin",
+          "rawSkinName": "game_character_skin_displayname_Jhin_3",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Dark Harvest",
+              "id": 8128,
+              "rawDescription": "perk_tooltip_DarkHarvest",
+              "rawDisplayName": "perk_displayname_DarkHarvest"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Precision",
+              "id": 8000,
+              "rawDescription": "perkstyle_tooltip_7201",
+              "rawDisplayName": "perkstyle_displayname_7201"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 3,
+          "skinName": "SKT T1 Jhin",
+          "summonerName": "SzczodryMarynarz",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Barrier",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerBarrier_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerBarrier_DisplayName"
+            }
+          },
+          "team": "CHAOS"
+        },
+        {
+          "championName": "Lissandra",
+          "isBot": false,
+          "isDead": false,
+          "items": [],
+          "level": 1,
+          "position": "NONE",
+          "rawChampionName": "game_character_displayname_Lissandra",
+          "rawSkinName": "game_character_skin_displayname_Lissandra_3",
+          "respawnTimer": 0,
+          "runes": {
+            "keystone": {
+              "displayName": "Electrocute",
+              "id": 8112,
+              "rawDescription": "perk_tooltip_Electrocute",
+              "rawDisplayName": "perk_displayname_Electrocute"
+            },
+            "primaryRuneTree": {
+              "displayName": "Domination",
+              "id": 8100,
+              "rawDescription": "perkstyle_tooltip_7200",
+              "rawDisplayName": "perkstyle_displayname_7200"
+            },
+            "secondaryRuneTree": {
+              "displayName": "Sorcery",
+              "id": 8200,
+              "rawDescription": "perkstyle_tooltip_7202",
+              "rawDisplayName": "perkstyle_displayname_7202"
+            }
+          },
+          "scores": {
+            "assists": 0,
+            "creepScore": 0,
+            "deaths": 0,
+            "kills": 0,
+            "wardScore": 0
+          },
+          "skinID": 3,
+          "skinName": "Program Lissandra",
+          "summonerName": "JALLLAA",
+          "summonerSpells": {
+            "summonerSpellOne": {
+              "displayName": "Mark",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerSnowball_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerSnowball_DisplayName"
+            },
+            "summonerSpellTwo": {
+              "displayName": "Flash",
+              "rawDescription": "GeneratedTip_SummonerSpell_SummonerFlash_Description",
+              "rawDisplayName": "GeneratedTip_SummonerSpell_SummonerFlash_DisplayName"
+            }
+          },
+          "team": "CHAOS"
+        }
+      ]
     }
   },
   "feature": "live_client_data"
@@ -982,7 +840,7 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 matchStarted | game_info   | true/false (string)       |See [notes](#matchStarted-note)|   140.0       |
 matchId      | game_info   | Current match id          |See [notes](#matchId-note)     |   120.0       |
 queueId      | game_info   | Current match [queue id](https://developer.riotgames.com/game-constants.html)|  **This event is not available anymore**        |   120.0       |
@@ -1025,7 +883,7 @@ matchEnd   | null        |  Match has ended     |  Match is ended    |   140.0  
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ----------- | ------------------------- | --------------------- | -------------- | 
+------------ | ----------- | ------------------------- | --------------------- | -------------- |
 pseudo_match_id | match_info | Current match’s ID code. Example:</br> `a4e8fc75-b35e-466f-976c-09f4ee633d95`  |  This is an Overwolf-generated code unrelated to Riot Games.  |   0.130 |
 game_mode | match_info | Whether the current game mode is TFT or default LoL. See [notes](#game_mode-notes) |                 |   133.0       |
 match_paused | match_info | Whether a match is paused or not (Bool - True/False). See [notes](#match_paused-notes) |                 |   153.1       |
@@ -1034,7 +892,7 @@ match_paused | match_info | Whether a match is paused or not (Bool - True/False)
 
 Data example:
 
-`{"info":{"match_info":{"game_mode":"tft"}},"feature":"match_info"}`  
+`{"info":{"match_info":{"game_mode":"tft"}},"feature":"match_info"}`
 `{"info":{"match_info":{"game_mode":"lol"}},"feature":"match_info"}`
 
 #### *match_paused* note
@@ -1051,7 +909,7 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                            | Notes                 | Since GEP Ver. |
------------- | ------------| --------------------------------- | --------------------- | ------------- | 
+------------ | ------------| --------------------------------- | --------------------- | ------------- |
 deaths       | game_info   | Number of deaths for this session |See [notes](#deaths-note)|   77.0        |
 
 #### *deaths* note
@@ -1066,7 +924,7 @@ Data Example:
 
 Event | Event Data                        | Fired When                  | Notes              | Since GEP Ver. |
 ------| ----------------------------------| --------------------------- | ------------------ | --------------|
-death | Number of deaths for this session | The player’s champion died  | See [notes](#death-note) |     77.0      | 
+death | Number of deaths for this session | The player’s champion died  | See [notes](#death-note) |     77.0      |
 
 #### *death* note
 
@@ -1082,7 +940,7 @@ Data Example:
 
 Event      | Event Data  | Fired When          | Notes              | Since GEP Ver. |
 -----------| ------------| ------------------------------- | ------------------ | --------------|
-respawn    | null        | The player’s champion respawned | See [notes](#respawn-notes) |   140.0       | 
+respawn    | null        | The player’s champion respawned | See [notes](#respawn-notes) |   140.0       |
 
 #### *respawn* note
 
@@ -1098,8 +956,8 @@ Data Example:
 
 Event      | Event Data  | Fired When          | Notes              | Since GEP Ver. |
 -----------| ------------| ------------------------------- | ------------------ | --------------|
-ability    | ability number | player has selected an ability	 |  <ul><li>abilities are numbered from 1-4 “ability”</li><li>event is fired when the player clicked an ability key (but he may cancel the ability action later)</li></ul>  |   140.0       | 
-usedAbility  | JSON containing: “type” with the ability number between 1-4. Example:</br> `{ type: "4" }` for ult        | player activated the ability	 |  “usedAbility” fired when the player actually activated the ability  |   0.31       | 
+ability    | ability number | player has selected an ability	 |  <ul><li>abilities are numbered from 1-4 “ability”</li><li>event is fired when the player clicked an ability key (but he may cancel the ability action later)</li></ul>  |   140.0       |
+usedAbility  | JSON containing: “type” with the ability number between 1-4. Example:</br> `{ type: "4" }` for ult        | player activated the ability	 |  “usedAbility” fired when the player actually activated the ability  |   0.31       |
 
 #### *ability* note
 
@@ -1125,7 +983,7 @@ Data Example:
 ### Info Updates
 
 key         | Category    | Values                          | Notes                 | Since GEP Ver. |
------------ | ------------| --------------------------------| --------------------- | ------------- | 
+----------- | ------------| --------------------------------| --------------------- | ------------- |
 kills       | game_info   | Total kills in the match        | See [notes](#kills-note) |   35.0        |
 doubleKills | game_info   | Total double-kills in the match |                       |   35.0        |
 tripleKills | game_info   | Total triple-kills in the match |                       |   35.0        |
@@ -1146,7 +1004,7 @@ pentaKills  | game_info   | Total penta-kills in the match  |                   
 
 Event | Event Data                        | Fired When                  | Notes              | Since GEP Ver. |
 ------| ----------------------------------| --------------------------- | ------------------ | --------------|
-kill | A JSON containing:</br><ul><li>count: Number of times this kill type happened in the match</li><li>label: kill / double_kill / triple_kill / quadra_kill / penta_kill</li><li>totalKills: Total kills in this match</li></ul> | Killing another champion  |See [notes](#kill-note)|     70.0      | 
+kill | A JSON containing:</br><ul><li>count: Number of times this kill type happened in the match</li><li>label: kill / double_kill / triple_kill / quadra_kill / penta_kill</li><li>totalKills: Total kills in this match</li></ul> | Killing another champion  |See [notes](#kill-note)|     70.0      |
 
 #### *kill* note
 
@@ -1177,7 +1035,7 @@ Data Example:
 ### Info Updates
 
 key    | Category    | Values                          | Notes                 | Since GEP Ver. |
--------| ------------| --------------------------------| --------------------- | ------------- | 
+-------| ------------| --------------------------------| --------------------- | ------------- |
 gold   | game_info   | numeric value – amount of gold  | See [notes](#gold-notes) |  70.00         |
 
 #### *gold* note
@@ -1193,7 +1051,7 @@ Data Example:
 ### Info Updates
 
 key                | Category    | Values                                         | Notes  | Since GEP Ver. |
--------------------| ------------| -----------------------------------------------| ------ | ------------- | 
+-------------------| ------------| -----------------------------------------------| ------ | ------------- |
 minionKills        | game_info   | amount of enemy minions killed by the player   |See [notes](#minionKills-note)|    70.0       |
 neutralMinionKills | game_info   | amount of neutral minions killed by the player |See [notes](#neutralMinionKills-note)|    70.0      |
 
@@ -1218,7 +1076,7 @@ Data Example:
 ### Info Updates
 
 key       | Category        | Values                                         | Notes                                                   | Since GEP Ver. |
-----------| ----------------| -----------------------------------------------| ------------------------------------------------------- | ------------- | 
+----------| ----------------| -----------------------------------------------| ------------------------------------------------------- | ------------- |
 id        | summoner_info   | User’s Summoner Id                         |   Fired immediately with game start. Check [notes](#id-note) |      70.0      |
 region    | summoner_info   | User’s region (EUE, EUW, etc.) or PBE client (See notes)             |   Important note: Push runes/items feature is not allowed (by Riot) on Korea region, so in case your app provides such a feature, make sure to disable it for KR users. Also, check [notes](#region-note)|    70.0        |
 champion  | summoner_info   | Name of the selected champion              |  All champion names (provided by the Overwolf Game Events Provider) match the champion-key from the Riot API, except for `Fiddlesticks`.</br><ul><li>Game Events Provider value: “FiddleSticks”</li><li>Riot API value: “Fiddlesticks”</li></ul></br>Also, check [notes](#champion-note)  |    70.0 |
@@ -1323,7 +1181,7 @@ Data Example:
 ### Info Updates
 
 key         | Category    | Values                                                                                | Notes                 | Since GEP Ver. |
------------ | ------------| --------------------------------------------------------------------------------------| --------------------- | ------------- | 
+----------- | ------------| --------------------------------------------------------------------------------------| --------------------- | ------------- |
 teams       | game_info   |  A URI – decoded string that represents a JSON object with the teams formation        |   Need to decodeURI() the value and then JSON.parse() the result. See example below.                    |   70.0        |
 
 Lets assume we save the data in a variable called `info`. It will be the equivalent of:
@@ -1339,7 +1197,7 @@ var info = {"info":[{"category":"game_info","key":"teams","value":
 %7B%22team%22:%22Chaos%22,%22champion%22:%22Orianna%22,%22skinId%22:%220%22,%22summoner%22:%22lp%20omg%20cartman%22%7D,
 %7B%22team%22:%22Chaos%22,%22champion%22:%22Ryze%22,%22skinId%22:%227%22,%22summoner%22:%22bigmoney%C5%82egolas%22%7D,
 %7B%22team%22:%22Chaos%22,%22champion%22:%22Malzahar%22,%22skinId%22:%220%22,%22summoner%22:%22hell0w0rld%22%7D,
-%7B%22team%22:%22Chaos%22,%22champion%22:%22Kayn%22,%22skinId%22:%220%22,%22summoner%22:%22erikolo878%22%7D%5D"}]} 
+%7B%22team%22:%22Chaos%22,%22champion%22:%22Kayn%22,%22skinId%22:%220%22,%22summoner%22:%22erikolo878%22%7D%5D"}]}
 ```
 
 So now we will decode the value:
@@ -1374,61 +1232,68 @@ var teams = JSON.parse(decoded);
 ### Info Updates
 
 key       | Category        | Values                                         | Notes                                                   | Since GEP Ver. |
-----------| ----------------| -----------------------------------------------| ------------------------------------------------------- | ------------- | 
+----------| ----------------| -----------------------------------------------| ------------------------------------------------------- | ------------- |
 level     | level           | Current level of the player's champion                 |   Fired immediately when game starts, updates whenever the champion levels up                     |      0.19     |
 
+```json
+{ "info": {
+    "level": { "level": "1" }
+  },
+  "feature": "level"
+}
+```
 ## `announcer`
 
 ### Events
 
 Event             | Event Data                           | Fired When (announcement)                   | Notes              | Since GEP Ver. |
 ------------------| -------------------------------------| ------------------------------------------- | ------------------ | --------------|
-welcome_rift      | null                                 | “Welcome to Summoner’s Rift!”               |                    |     70.05      | 
-minions_30_sec    | null                                 | “Thirty seconds until minions spawn!”       |                    |     70.05      | 
-minions_spawn     | null                                 | “Minions have spawned!”                     |                    |     70.05      | 
-first_blood       | null                                 | “First Blood!”                              |                    |     70.05      | 
-defeat            | null                                 | “Defeat!”                                   |                    |     70.05      | 
-victory           | null                                 | “Victory!”                                  |                    |     75.0      | 
-shutdown          | null                                 | “Shut down!”                                |                    |     75.0      | 
-ace               | null                                 | “Aced!”                                     |                    |     75.0      | 
-slain             | “team”                               | “An enemy has been slain!!”                 |                    |     75.0      | 
-self_slain        | “team”                               | “You have slain an enemy!!”                 |                    |     75.0      | 
-killing_spree     | “team”                               | “Killing Spree!”                            |                    |     75.0      | 
-rampage           | “team”                               | “Rampage!”                                  |                    |     75.0      | 
-unstoppable       | “team”                               | “Unstoppable”                               |                    |     75.0      | 
-dominating        | “team”                               | “Dominating!”                               |                    |     75.0      | 
-godlike           | “team”                               | “Godlike!”                                  |                    |     75.0      | 
-legendary         | “team”                               | “Legendary!”                                |                    |     75.0      | 
-double_kill       | “team”                               | “Double Kill!”                              |                    |     75.0      | 
-triple_kill       | “team”                               | “Triple Kill!”                              |                    |     75.0      | 
-quadra_kill       | “team”                               | “Quadra Kill!”                              |                    |     75.0      | 
-penta_kill        | “team”                               | “Penta Kill!”                               |                    |     75.0      | 
-turret_destroy    | "team"                               | “Your turret has been destroyed!”           |                    |     75.0      | 
-inhibitor_destroy | “team”                               | “Your inhibitor has been destroyed!”        |                    |     75.0      | 
-inhibitor_respawn | “team”                               | “Your inhibitor is respawning soon!”        |                    |     75.0      | 
-slain             | "enemy"                              | “An ally has been slain!”                   |                    |     75.0      | 
-slain_self        | “enemy”                              | “You have been slain!”                      |                    |     75.0      | 
-killing_spree     | “enemy”                              | “Enemy Killing Spree!”                      |                    |     75.0      | 
-rampage           | “enemy”                              | “Enemy Rampage!”                            |                    |     75.0      | 
-unstoppable       | “enemy”                              | “An enemy is Unstoppable!”                  |                    |     75.0      | 
-dominating        | “enemy”                              | “An enemy is Dominating!”                   |                    |     75.0      | 
-godlike           | “enemy”                              | “An enemy is Godlike!”                      |                    |     75.0      | 
-double_kill       | “enemy”                              | “Enemy Double Kill!”                        |                    |     75.0      | 
-triple_kill       | “enemy”                              | “Enemy Triple Kill!”                        |                    |     75.0      | 
-quadra_kill       | “enemy”                              | “Enemy Quadra Kill!”                        |                    |     75.0      | 
-penta_kill        | “enemy”                              | “Enemy Penta Kill!”                         |                    |     75.0      | 
-inhibitor_destroy | “enemy”                              | “Your team has destroyed an inhibitor!”     |                    |     75.0      | 
-inhibitor_respawn | “enemy”                              | “The enemy’s inhibitor is respawning soon!” |                    |     75.0      | 
-turret_destroy    | “enemy”                              | “Your team has destroyed a turret!”         |                    |     75.0      | 
-executed          | "minion"                             | “Executed!”                                 |                    |     75.0      | 
-executed          | "tower"                              | “Executed!”                                 |                    |     75.0      | 
+welcome_rift      | null                                 | “Welcome to Summoner’s Rift!”               |                    |     70.05      |
+minions_30_sec    | null                                 | “Thirty seconds until minions spawn!”       |                    |     70.05      |
+minions_spawn     | null                                 | “Minions have spawned!”                     |                    |     70.05      |
+first_blood       | null                                 | “First Blood!”                              |                    |     70.05      |
+defeat            | null                                 | “Defeat!”                                   |                    |     70.05      |
+victory           | null                                 | “Victory!”                                  |                    |     75.0      |
+shutdown          | null                                 | “Shut down!”                                |                    |     75.0      |
+ace               | null                                 | “Aced!”                                     |                    |     75.0      |
+slain             | “team”                               | “An enemy has been slain!!”                 |                    |     75.0      |
+self_slain        | “team”                               | “You have slain an enemy!!”                 |                    |     75.0      |
+killing_spree     | “team”                               | “Killing Spree!”                            |                    |     75.0      |
+rampage           | “team”                               | “Rampage!”                                  |                    |     75.0      |
+unstoppable       | “team”                               | “Unstoppable”                               |                    |     75.0      |
+dominating        | “team”                               | “Dominating!”                               |                    |     75.0      |
+godlike           | “team”                               | “Godlike!”                                  |                    |     75.0      |
+legendary         | “team”                               | “Legendary!”                                |                    |     75.0      |
+double_kill       | “team”                               | “Double Kill!”                              |                    |     75.0      |
+triple_kill       | “team”                               | “Triple Kill!”                              |                    |     75.0      |
+quadra_kill       | “team”                               | “Quadra Kill!”                              |                    |     75.0      |
+penta_kill        | “team”                               | “Penta Kill!”                               |                    |     75.0      |
+turret_destroy    | "team"                               | “Your turret has been destroyed!”           |                    |     75.0      |
+inhibitor_destroy | “team”                               | “Your inhibitor has been destroyed!”        |                    |     75.0      |
+inhibitor_respawn | “team”                               | “Your inhibitor is respawning soon!”        |                    |     75.0      |
+slain             | "enemy"                              | “An ally has been slain!”                   |                    |     75.0      |
+slain_self        | “enemy”                              | “You have been slain!”                      |                    |     75.0      |
+killing_spree     | “enemy”                              | “Enemy Killing Spree!”                      |                    |     75.0      |
+rampage           | “enemy”                              | “Enemy Rampage!”                            |                    |     75.0      |
+unstoppable       | “enemy”                              | “An enemy is Unstoppable!”                  |                    |     75.0      |
+dominating        | “enemy”                              | “An enemy is Dominating!”                   |                    |     75.0      |
+godlike           | “enemy”                              | “An enemy is Godlike!”                      |                    |     75.0      |
+double_kill       | “enemy”                              | “Enemy Double Kill!”                        |                    |     75.0      |
+triple_kill       | “enemy”                              | “Enemy Triple Kill!”                        |                    |     75.0      |
+quadra_kill       | “enemy”                              | “Enemy Quadra Kill!”                        |                    |     75.0      |
+penta_kill        | “enemy”                              | “Enemy Penta Kill!”                         |                    |     75.0      |
+inhibitor_destroy | “enemy”                              | “Your team has destroyed an inhibitor!”     |                    |     75.0      |
+inhibitor_respawn | “enemy”                              | “The enemy’s inhibitor is respawning soon!” |                    |     75.0      |
+turret_destroy    | “enemy”                              | “Your team has destroyed a turret!”         |                    |     75.0      |
+executed          | "minion"                             | “Executed!”                                 |                    |     75.0      |
+executed          | "tower"                              | “Executed!”                                 |                    |     75.0      |
 
 ## `counters`
 
 ### Info Updates
 
 key  | Category    | Values                                     | Notes  | Since GEP Ver. |
------| ------------| -------------------------------------------| ------ | ------------- | 
+-----| ------------| -------------------------------------------| ------ | ------------- |
 ping | performance | The change in latency values of the local player  |See [notes](#ping-note)|    128.0      |
 
 ### Events
@@ -1465,7 +1330,7 @@ The information provided by this feature is incorrect at the moment. Please use 
 ### Info Updates
 
 key  | Category    | Values                                     | Notes  | Since GEP Ver. |
------| ------------| -------------------------------------------| ------ | ------------- | 
+-----| ------------| -------------------------------------------| ------ | ------------- |
 total_damage_dealt               | damage | Value of all damage done in the match (Float). |See [notes](#total_damage_dealt-note)|    139.0      |
 total_damage_dealt_to_champions  | damage | Value of all damage done to champions in the match (Float). |See [notes](#total_damage_dealt_to_champions-note)|    139.0      |
 total_damage_taken               | damage | Value of all the damage that was taken in the match (Float). |See [notes](#total_damage_taken-note)|    139.0      |
@@ -1621,7 +1486,7 @@ Data Example:
 ### Info Updates
 
 key  | Category    | Values                                     | Notes  | Since GEP Ver. |
------| ------------| -------------------------------------------| ------ | ------------- | 
+-----| ------------| -------------------------------------------| ------ | ------------- |
 total_heal              | heal | Value of all healing done in the match (Float). |See [notes](#total_heal-note)|    139.0      |
 total_heal_on_teammates | heal | Value of all healing on teammates in the match (Float). |See [notes](#total_heal_on_teammates-note)|    139.0      |
 total_units_healed      | heal | Value of amount of units healed in the match (Float). |See [notes](#total_units_healed-note)|    139.0      |

--- a/docs/api/overwolf-games-events-rocket-league.md
+++ b/docs/api/overwolf-games-events-rocket-league.md
@@ -35,7 +35,7 @@ It's recommended to communicate errors and warnings to your users. You can check
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 gep_internal | gep_internal| Local + Public version number|See [notes](#gep_internal-note)|   143.0       |
 
 #### *gep_internal* note
@@ -48,12 +48,37 @@ Data Example:
 
 ## `stats`
 
+### Info Updates
+
+key          | Category    | Values                    | Notes                 | Since GEP Ver. |
+------------ | ------------| ------------------------- | --------------------- | ------------- |
+player0 / player1 … palyerN(N = number of players in the match)| playersInfo| Check notes |See [notes](#player-note)|    14.0   |
+
+#### *player* note
+
+* Encoded stringified JSON containing the properties:
+  * steamId – Steam ID of the player who died
+  * score – Score of the player who died
+  * goals – Goal count of the player
+  * name –  Name of the player that died
+  * team – Team number of the player (1 or 2)
+
+Comment:
+
+Encoded stringified JSON containing the properties. Need to do a decodeURI() on the value and then JSON.parse() on the result.
+
+Data Example:
+
+```json
+{"info":{"playersInfo":{"player0":"%7B%22steamId%22:%222535466851496806%22,%22score%22:52,%22goals%22:%220%22,%22name%22:%22Daknowntesco%22,%22state%22:%220%22,%22team_score%22:0,%22team%22:%221%22,%22local%22:%220%22,%22index%22:0%7D"}},"feature":"roster"}
+```
+
 ### Events
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-goal        | Check notes  | A goal has been scored |See [notes](#goal-note)|     14.0      | 
-score       | Check notes  | Score of a player has changed|See [notes](#score-note)|     86.0      | 
+goal        | Check notes  | A goal has been scored |See [notes](#goal-note)|     14.0      |
+score       | Check notes  | Score of a player has changed|See [notes](#score-note)|     86.0      |
 
 #### *goal* note
 
@@ -108,7 +133,7 @@ Data Example:
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-teamGoal    | null         |When the local player’s team has scored a goal|See [notes](#teamGoal-note)|   131.0   | 
+teamGoal    | null         |When the local player’s team has scored a goal|See [notes](#teamGoal-note)|   131.0   |
 
 #### *teamGoal* note
 
@@ -124,7 +149,7 @@ Data Example:
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-opposingTeamGoal| null     |When the opposing team has scored a goal|See [notes](#oppopsingTeamGoal-note)|   131.0   | 
+opposingTeamGoal| null     |When the opposing team has scored a goal|See [notes](#oppopsingTeamGoal-note)|   131.0   |
 
 #### *opposingTeamGoal* note
 
@@ -139,11 +164,11 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
-started      | matchState  | true / false              |                       |    14.0       |
-ended        | matchState  | true / false              |                       |    86.0       |
+------------ | ------------| ------------------------- | --------------------- | ------------- |
+started      | matchState  | "true" / "false"          |                       |    14.0       |
+ended        | matchState  | "true" / "false"          |                       |    86.0       |
 matchType    | matchInfo   | Current match type            |See [notes](#matchType-note)|    86.0  |
-ranked       | matchInfo   | True if the match is ranked, false otherwise "True/False" |     |  86.0  |
+ranked       | matchInfo   | True if the match is ranked, false otherwise "true"/"false" |     |  86.0  |
 maxPlayers   | matchInfo   | Maximum number of players allowed in this match |See [notes](#maxPlayers-note)|    86.0       |
 gameMode     | matchInfo   | Game mode of the match |See [notes](#gameMode-note)|    86.0       |
 gameState    | matchInfo   | Current state of the game|See [notes](#gameState-note)|    86.0       |
@@ -153,7 +178,7 @@ gameType     | matchInfo   | Current game type           |                      
 
 Data Example:
 
-`[“Lobby” | “Private” | “Online” | “Offline”]`
+`["Lobby" | "Private" | "Online" | "Offline"]`
 
 Data Example:
 
@@ -175,13 +200,13 @@ Data Example:
 
 Data Example:
 
-`[“soccar” | “basketball”, “hockey”, “items”, “volleyball”, “breakout”, “playTest”]`
+`["Soccar" | "Basketball" | "Hockey" | "Items" | "Breakout" | "Unknown"]`
 
 #### *gameState* note
 
 Data Example:
 
-`[“waitingForPlayers” | “countdown | “active” | “postGoalScored” | “ReplayPlayback” | “PrePodiumSpotlight” | “Finished” | “Unknown” | “PodiumSpotlight”]`
+`["WaitingForPlayers" | "Countdown | "Active" | "PostGoalScored" | "ReplayPlayback" | "PrePodiumSpotlight" | "Finished" | "Unknown" | "PodiumSpotlight"]`
 
 ```json
 {"info":{"matchInfo":{"gameState":"WaitingForPlayers"}},"feature":"match"}
@@ -191,10 +216,10 @@ Data Example:
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-matchStart  | null         | Match starts  |See [notes](#matchStart-note)|      14.0     | 
-matchEnd    | null         | Match ends    |See [notes](#matchEnd-note)|      14.0     | 
-victory     | null     |team_score (1 / 2)(1 – Victory, 2 - defeat)|    |   86.0   | 
-defeat      | null     |team_score (1 / 2)(1 – Victory, 2 - defeat)|    |   86.0   | 
+matchStart  | null         | Match starts  |See [notes](#matchStart-note)|      14.0     |
+matchEnd    | null         | Match ends    |See [notes](#matchEnd-note)|      14.0     |
+victory     | null     |team_score (1 / 2)(1 – Victory, 2 - defeat)|    |   86.0   |
+defeat      | null     |team_score (1 / 2)(1 – Victory, 2 - defeat)|    |   86.0   |
 
 #### *matchStart* note
 
@@ -233,12 +258,11 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 pseudo_match_id| match_info| Current match’s internal ID code.|See [notes](#pseudo_match_id-note)|    130.0   |
 mutator_settings| match_info| The current-chosen settings of the private match.|See [notes](#mutator_settings-note)|    147.0   |
 arena        | match_info| The current private match's arena setting. |See [notes](#arena-note)|    147.0   |
 server_info  | match_info| The info of the current match's server info. |See [notes](#server_info-note)|    147.0   |
-action_points  | match_info| Name of action that granted a score to local player. |See [notes](#action_points-note)|    160.0   |
 
 #### *pseudo_match_id* note
 
@@ -270,6 +294,12 @@ Data Example:
 {"info":{"match_info":{"server_info":"EU511-Gimbal9"}},"feature":"match_info"}
 ```
 
+### Events
+
+Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
+------------| -------------| --------------| ------------------ | --------------|
+action_points  | match_info| Name of action that granted a score to local player. |See [notes](#action_points-note)|    160.0   |
+
 #### *action_points* note
 
 Data Examples:
@@ -292,7 +322,7 @@ Data Examples:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 player0 / player1 … palyerN(N = number of players in the match)| playersInfo| Check notes |See [notes](#player-note)|    14.0   |
 team1 / team2| teamsInfo | Check notes |See [notes](#teamsInfo-note)|    24.0   |
 team1_score / team2_score| teamsScore|team1 / team2 score – integer|See [notes](#pseudo_match_id-note)|    86.0   |
@@ -332,9 +362,9 @@ Data Example
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-rosterChange| Array containing players' information|A player leaves or joins the match|See [notes](#rosterChange-note)|      14.0     | 
-playerJoined| Check notes |A player joins the match|See [notes](#playerJoined-note)|      24.0     | 
-playerLeft  | Check notes |A player leaves the match|See [notes](#playerLeft-note)|      24.0     | 
+rosterChange| Array containing players' information|A player leaves or joins the match|See [notes](#rosterChange-note)|      14.0     |
+playerJoined| Check notes |A player joins the match|See [notes](#playerJoined-note)|      24.0     |
+playerLeft  | Check notes |A player leaves the match|See [notes](#playerLeft-note)|      24.0     |
 
 #### *rosterChange* note
 
@@ -381,7 +411,7 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 steamId      | me          | Player’s Steam ID     |                       |    14.0       |
 name         | me          | Player’s name         |                       |    14.0       |
 goals        | me          | Player’s goal count  |                       |    14.0       |
@@ -405,7 +435,7 @@ Data Examples:
 
 Event       | Event Data   | Fired When    | Notes              | Since GEP Ver. |
 ------------| -------------| --------------| ------------------ | --------------|
-death       | null |A player is demolished by an opponent. |See [notes](#death-note)|      160.0     | 
+death       | null |A player is demolished by an opponent. |See [notes](#death-note)|      160.0     |
 
 #### *death* note
 
@@ -421,8 +451,8 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
-trade_menu_opened         | game_info | true / false   | See [notes](#trade_menu_opened-note) |    170.3       |
+------------ | ------------| ------------------------- | --------------------- | ------------- |
+trade_menu_opened         | game_info | "true" / "false"   | See [notes](#trade_menu_opened-note) |    170.3       |
 trade_my_proposition      | game_info | Local player's items that are on offer. | See [notes](#trade_my_proposition-note) |    170.3       |
 trade_opponent_proposition| game_info | Team member's items that are on offer. | See [notes](#trade_opponent_proposition-note) |    170.3       |
 

--- a/docs/api/overwolf-games-events-tft.md
+++ b/docs/api/overwolf-games-events-tft.md
@@ -373,54 +373,54 @@ Data example:
   "info": {
     "roster": {
       "player_status": "{
-         \"Zedester\": {
-            \"index\":1,
-            \"health\":76,
-            \"xp\":5,
-            \"localplayer\":true,
-            \"rank\":0
+         "Zedester": {
+            "index": 1,
+            "health": 76,
+            "xp": 5,
+            "localplayer": true,
+            "rank": 0
          },
-         \"littlemelony\": {
-            \"index\":2,
-            \"health\":94,
-            \"xp\":4,
-            \"localplayer\":false,
-            \"rank\":0
+         "littlemelony": {
+            "index": 2,
+            "health": 94,
+            "xp": 4,
+            "localplayer": false,
+            "rank": 0
          },
-         \"XKrosX\": {
-            \"index\":3,
-            \"health\":88,
-            \"xp\":6,
-            \"localplayer\":false,
-            \"rank\":0
+         "XKrosX": {
+            "index": 3,
+            "health": 88,
+            "xp": 6,
+            "localplayer": false,
+            "rank": 0
          },
-         \"UP GuyFromMiddle\": {
-            \"index\":4,
-            \"health\":62,
-            \"xp\":6,
-            \"localplayer\":false,
-            \"rank\":0
+         "UP GuyFromMiddle": {
+            "index": 4,
+            "health": 62,
+            "xp": 6,
+            "localplayer": false,
+            "rank": 0
          },
-         \"Storas Tevas\": {
-            \"index\":5,
-            \"health\":90,
-            \"xp\":4,
-            \"localplayer\":false,
-            \"rank\":0
+         "Storas Tevas": {
+            "index": 5,
+            "health": 90,
+            "xp": 4,
+            "localplayer": false,
+            "rank": 0
          },
-         \"MAYAH MELISSA\": {
-            \"index\":6,
-            \"health\":100,
-            \"xp\":4,
-            \"localplayer\":false,
-            \"rank\":0
+         "MAYAH MELISSA": {
+            "index": 6,
+            "health": 100,
+            "xp": 4,
+            "localplayer": false,
+            "rank": 0
          },
-         \"TabsWay\": {
-            \"index\":7,
-            \"health\":92,
-            \"xp\":5,
-            \"localplayer\":false,
-            \"rank\":0
+         "TabsWay": {
+            "index": 7,
+            "health": 92,
+            "xp": 5,
+            "localplayer": false,
+            "rank": 0
          },
       }"
     }
@@ -486,24 +486,25 @@ Data Example:
 {
    "info":{
       "board":{
-         "board_pieces":"{"         cell_9":{
-            "name":"TFT_Tristana",
-            "level":"1",
-            "item_1":"TFT_Item_GuinsoosRageblade",
-            "item_2":"",
-            "item_3":""
-         },
-         "cell_16":{
-            "name":"TFT_KhaZix",
-            "level":"1",
-            "item_1":"",
-            "item_2":"",
-            "item_3":""
-         }
-      }      "
+         "board_pieces":"{
+            "cell_9":{
+               "name":"TFT_Tristana",
+               "level":"1",
+               "item_1":"TFT_Item_GuinsoosRageblade",
+               "item_2":"",
+               "item_3":""
+            },
+            "cell_16":{
+               "name":"TFT_KhaZix",
+               "level":"1",
+               "item_1":"",
+               "item_2":"",
+               "item_3":""
+            }
+         }"
       }
    },
-   "      feature":"board"
+   "feature":"board"
    }
 ```
 

--- a/docs/api/overwolf-games-events-tft.md
+++ b/docs/api/overwolf-games-events-tft.md
@@ -10,7 +10,7 @@ Please read the [overwolf.games.events](overwolf-games-events) documentation pag
 5426
 :::
 
-**Note** that TFT and LOL share the same Game ID.  
+**Note** that TFT and LOL share the same Game ID.
 
 :::tip
 If you would like to know when the user is going to play TFT (hit the "Play" button), you can listen to the LoL Launcher [lobby_info](overwolf-games-launchers-events-lol#info-updates-3) info-update, and check the `queueID`. If it's 1090 or 1100 - it's TFT.
@@ -48,7 +48,7 @@ Because LOL and TFT share the same GameID, when checking TFTs game event status 
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 gep_internal | gep_internal| Local + Public version number|See [notes](#gep_internal-note)|   143.0       |
 
 #### *gep_internal* note
@@ -64,7 +64,7 @@ Data Example:
 ### Info Updates
 
 key          | Category    | Values                    | Notes                 | Since GEP Ver. |
------------- | ------------| ------------------------- | --------------------- | ------------- | 
+------------ | ------------| ------------------------- | --------------------- | ------------- |
 active_player | live_client_data | In-game data received by the client. |See [notes](#active_player-note)|   143.1    |
 all_players | live_client_data | In-game data received by the client. |See [notes](#all_players-note)|   143.1   |
 events | live_client_data | In-game data received by the client. |See [notes](#events-note)|   143.1  |
@@ -75,14 +75,14 @@ game_data | live_client_data | In-game data received by the client. |See [notes]
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "live_client_data":{ 
+{
+   "info":{
+      "live_client_data":{
          "active_player":"{"abilities":{"E":{"abilityLevel":5,"displayName":"Unspeakable Horror","id"
          :"NocturneUnspeakableHorror"
          ,"rawDescription":"GeneratedTip_Spell_NocturneUnspeakableHorror_Description"
          ...
-         ,"rawDisplayName":"GeneratedTip_Spell_NocturneUnspeakableHorror_DisplayName"}  
+         ,"rawDisplayName":"GeneratedTip_Spell_NocturneUnspeakableHorror_DisplayName"}
 {"id":5008,"rawDescriptio":"perk_tooltip_StatModAdaptive"},{"id":5002,"rawDescription":"perk_tooltip_StatModArmor"}]},"level":17,"summonerName":"Sh4rgaas"}"
       }
    },
@@ -95,9 +95,9 @@ Data Example:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "live_client_data":{ 
+{
+   "info":{
+      "live_client_data":{
          "all_players":"[{"championName":"Sett","isBot":false,"isDead":true,"items":
          [{"canUse":false,"consumable":false,"count":1,"displayName":"Dead Man's Plate"
       ,"itemID":3742,"price":1100,"rawDescription":"game_item_description_3742","rawDisplayName":"game_item_displayname_3742","slot":0}
@@ -118,14 +118,14 @@ Data Example:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "live_client_data":{ 
+{
+   "info":{
+      "live_client_data":{
          "events":"{"Events":[{"EventID":0,"EventName":"GameStart"
          ,"EventTime":0.041107501834630966},{"EventID":1,"EventName":"MinionsSpawning",
          "EventTime":65.05073547363281},{"Assisters":
          ["CHOWCHOWTHEPAIN","CHAXILICIOUSLOL"],
-...      
+...
 "EventID":2,"EventName":"ChampionKill","EventTime":321.79498291015625,"KillerName":"Adoucissant",
 "VictimName":"finite area"},{"Assisters":["finite area","Dilipa"],"EventID":101,"EventName":
          "ChampionKill","EventTime":2256.623291015625,"KillerName":"St4ubwedel","VictimName":"CHOWCHOWTHEPAIN"}]}"
@@ -140,9 +140,9 @@ Data Example:
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "live_client_data":{ 
+{
+   "info":{
+      "live_client_data":{
          "game_data":"{"gameMode":"CLASSIC","gameTime":2258.9697265625,"mapName":"Map11","mapNumber":11,"mapTerrain":"Mountain"}"
       }
    },
@@ -186,7 +186,7 @@ Data example:
 
 `{"info":{"me":{"rank":"2"}},"feature":"me"}`
 
-Meaning 1st place/8th place, etc. 
+Meaning 1st place/8th place, etc.
 
 ("Index" <b>rank</b> data in roster is not accurate in real-time - only once the local player had died or won).
 
@@ -354,11 +354,11 @@ The full roster of players will first appear during the loading screen.
 
 Each player object includes the following data:
 
-* summoner name
-* slot
+* index
 * health
-* xp level
-* rank 
+* xp
+* localplayer
+* rank
 
 Aside from summoner name which is received during the loading screen, the rest of the data mentioned above will be delivered once the actual game has begun.
 
@@ -369,72 +369,63 @@ The final & accurate rank position of each player in the match will be given onl
 Data example:
 
 ```json
-{  
-   "category":"game_info",
-   "key":"tft_roster",
-   "value":"[{summoner:Sh4rgaas}]",
-   "index":"1",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"1",
-   "rank":"0"
-},
-{  
-   "summoner":"Zedester",
-   "index":"2",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"littlemelony",
-   "index":"3",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"XKrosX",
-   "index":"4",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"UP GuyFromMiddle",
-   "index":"5",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"Storas Tevas",
-   "index":"6",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"MAYAH MELISSA",
-   "index":"7",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0"
-},
-{  
-   "summoner":"TabsWay",
-   "index":"8",
-   "health":"100",
-   "xp":"1",
-   "localplayer":"0",
-   "rank":"0\"}]",
-   "valueLength":772
+{
+  "info": {
+    "roster": {
+      "player_status": "{
+         \"Zedester\": {
+            \"index\":1,
+            \"health\":76,
+            \"xp\":5,
+            \"localplayer\":true,
+            \"rank\":0
+         },
+         \"littlemelony\": {
+            \"index\":2,
+            \"health\":94,
+            \"xp\":4,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+         \"XKrosX\": {
+            \"index\":3,
+            \"health\":88,
+            \"xp\":6,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+         \"UP GuyFromMiddle\": {
+            \"index\":4,
+            \"health\":62,
+            \"xp\":6,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+         \"Storas Tevas\": {
+            \"index\":5,
+            \"health\":90,
+            \"xp\":4,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+         \"MAYAH MELISSA\": {
+            \"index\":6,
+            \"health\":100,
+            \"xp\":4,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+         \"TabsWay\": {
+            \"index\":7,
+            \"health\":92,
+            \"xp\":5,
+            \"localplayer\":false,
+            \"rank\":0
+         },
+      }"
+    }
+  },
+  "feature": "roster"
 }
 ```
 
@@ -453,45 +444,45 @@ Once you purchase a champion, there will be a new update which indicates "Sold" 
 Data Example:
 
 ```json
-{  
-   "info":{  
-      "store":{  
+{
+   "info":{
+      "store":{
          "shop_pieces":"{
-         "slot_1":{  
+         "slot_1":{
             "name":"TFT_Blitzcrank"
          },
-         "slot_2":{  
+         "slot_2":{
             "name":"TFT_Garen"
          },
-         "slot_3":{  
+         "slot_3":{
             "name":"TFT_Nidalee"
          },
-         "slot_4":{  
+         "slot_4":{
             "name":"TFT_Mordekaiser"
          },
-         "slot_5":{  
+         "slot_5":{
             "name":"TFT_Ahri"
          }
       }      "}},"feature":"store"
    }
 
-{  
-   "info":{  
-      "store":{  
+{
+   "info":{
+      "store":{
          "shop_pieces":"{
-         "slot_1":{  
+         "slot_1":{
             "name":"TFT_Blitzcrank"
          },
-         "slot_2":{  
+         "slot_2":{
             "name":"Sold"
          },
-         "slot_3":{  
+         "slot_3":{
             "name":"TFT_Nidalee"
          },
-         "slot_4":{  
+         "slot_4":{
             "name":"TFT_Mordekaiser"
          },
-         "slot_5":{  
+         "slot_5":{
             "name":"TFT_Ahri"
          }
       }      "}},"feature":"store"
@@ -512,17 +503,17 @@ board_pieces   |    board    | Exact position of each chess piece on the grid, i
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "board":{ 
-         "board_pieces":"{"         cell_9":{ 
+{
+   "info":{
+      "board":{
+         "board_pieces":"{"         cell_9":{
             "name":"TFT_Tristana",
             "level":"1",
             "item_1":"TFT_Item_GuinsoosRageblade",
             "item_2":"",
             "item_3":""
          },
-         "cell_16":{ 
+         "cell_16":{
             "name":"TFT_KhaZix",
             "level":"1",
             "item_1":"",
@@ -549,52 +540,52 @@ bench_pieces   |    bench    | Exact position of each chess-piece on the bench i
 Data Example:
 
 ```json
-{ 
-   "info":{ 
-      "bench":{ 
-         "bench_pieces":"{"         slot_1":{ 
+{
+   "info":{
+      "bench":{
+         "bench_pieces":"{"         slot_1":{
             "name":"TFT_Garen",
             "level":"1",
             "item_1":"",
             "item_2":"",
             "item_3":""
          },
-         "slot_2":{ 
+         "slot_2":{
             "name":"TFT_Darius",
             "level":"2",
             "item_1":"",
             "item_2":"",
             "item_3":""
          },
-         "slot_3":{ 
+         "slot_3":{
             "name":"TFT_Leona",
             "level":"1",
             "item_1":"",
             "item_2":"",
             "item_3":""
          },
-         "slot_4":{ 
+         "slot_4":{
             "name":"TFT_Sejuani",
             "level":"1",
             "item_1":"",
             "item_2":"",
             "item_3":""
          },
-         "slot_5":{ 
+         "slot_5":{
             "name":"TFT_Leona",
             "level":"1",
             "item_1":"",
             "item_2":"",
             "item_3":""
          },
-         "slot_6":{ 
+         "slot_6":{
             "name":"TFT_Kayle",
             "level":"1",
             "item_1":"TFT_Item_RapidFirecannon",
             "item_2":"",
             "item_3":""
          },
-         "slot_9":{ 
+         "slot_9":{
             "name":"TFT_MissFortune",
             "level":"1",
             "item_1":"",
@@ -621,47 +612,47 @@ carousel_pieces   |   carousel  | Names of available champions in the carousel |
 Data Example:
 
 ```json
-{  
-   "info":{  
-      "carousel":{  
+{
+   "info":{
+      "carousel":{
          "carousel_pieces":"{
-         "slot_1":{  
+         "slot_1":{
             "name":"TFT_Morgana",
             "item_1":"0"
          },
-         "slot_2":{  
+         "slot_2":{
             "name":"TFT_Lissandra",
             "item_1":"0"
          },
-         "slot_3":{  
+         "slot_3":{
             "name":"TFT_Rengar",
             "item_1":"0"
          },
-         "slot_4":{  
+         "slot_4":{
             "name":"TFT_Veigar",
             "item_1":"0"
          },
-         "slot_5":{  
+         "slot_5":{
             "name":"TFT_Gangplank",
             "item_1":"0"
          },
-         "slot_6":{  
+         "slot_6":{
             "name":"TFT_Zed",
             "item_1":"0"
          },
-         "slot_7":{  
+         "slot_7":{
             "name":"TFT_Brand",
             "item_1":"0"
          },
-         "slot_8":{  
+         "slot_8":{
             "name":"TFT_Graves",
             "item_1":"0"
          },
-         "slot_9":{  
+         "slot_9":{
             "name":"TFT_Gnar",
             "item_1":"0"
          },
-         "slot_10":{  
+         "slot_10":{
             "name":"TFT_Chogath",
             "item_1":"0"
          }

--- a/docs/api/overwolf-games-events-tft.md
+++ b/docs/api/overwolf-games-events-tft.md
@@ -448,46 +448,26 @@ Data Example:
    "info":{
       "store":{
          "shop_pieces":"{
-         "slot_1":{
-            "name":"TFT_Blitzcrank"
-         },
-         "slot_2":{
-            "name":"TFT_Garen"
-         },
-         "slot_3":{
-            "name":"TFT_Nidalee"
-         },
-         "slot_4":{
-            "name":"TFT_Mordekaiser"
-         },
-         "slot_5":{
-            "name":"TFT_Ahri"
-         }
-      }      "}},"feature":"store"
-   }
-
-{
-   "info":{
-      "store":{
-         "shop_pieces":"{
-         "slot_1":{
-            "name":"TFT_Blitzcrank"
-         },
-         "slot_2":{
-            "name":"Sold"
-         },
-         "slot_3":{
-            "name":"TFT_Nidalee"
-         },
-         "slot_4":{
-            "name":"TFT_Mordekaiser"
-         },
-         "slot_5":{
-            "name":"TFT_Ahri"
-         }
-      }      "}},"feature":"store"
-   }
-
+            "slot_1":{
+               "name":"TFT_Blitzcrank"
+            },
+            "slot_2":{
+               "name":"TFT_Garen"
+            },
+            "slot_3":{
+               "name":"TFT_Nidalee"
+            },
+            "slot_4":{
+               "name":"TFT_Mordekaiser"
+            },
+            "slot_5":{
+               "name":"TFT_Ahri"
+            }
+         }"
+      }
+   },
+   "feature":"store"
+}
 ```
 
 ## `board`


### PR DESCRIPTION
- Mostly updating examples, event keys
- auto formatter removed ending spaces
- Rocket League emits `playerX` info updates under the `stats` feature, so added a section under `stats` to show it
  - possible bug? This is the same thing that is emitted in from the `roster` feature, but they don't emit together. That `stats`'s playerInfo emits throughtout the game, while the `rosters`'s playerInfo emits at the beginning of the match.