### PR TITLE
Update overwolf-games-events-rocket-league.md

### DIFF
--- a/docs/api/overwolf-games-events-rocket-league.md
+++ b/docs/api/overwolf-games-events-rocket-league.md
@@ -11,7 +11,7 @@ Please read the [overwolf.games.events](overwolf-games-events) documentation pag
 :::
 
 ## Sample Apps
-* [Rocket League game events sample app](https://github.com/overwolf/rocket-league-events-sample-app)
+* [Rocket League game events sample app](https://github.com/overwolf/events-sample-apps)
 
 ## Available Features
 


### PR DESCRIPTION
The link to the game events sample app was broken so I replaced with the general link that seems to be used for all the other games for the master game events app