### PR TITLE
updated manifest.mdx to remain consistent with implementation

### DIFF
--- a/website/pages/docs/api/manifest/manifest.mdx
+++ b/website/pages/docs/api/manifest/manifest.mdx
@@ -178,11 +178,12 @@ Note that not all flags are mandatory - we included all available flags for docu
         "window_icon": "windowIcon.png"
     },
     "permissions": ["Streaming","Hotkeys","GameInfo"],
-    "enable_top_isolation": true,
+    
     "max_rotation_log_files": 20,
     "data": {
         "game_targeting": {"type": "dedicated","game_ids": [10906, 7764]},
         "start_window": "windowName",
+        "enable_top_isolation": true,
         "windows": {
             "windowName": {
                 "file": "name.html",


### PR DESCRIPTION
[Manifest.json without fields summary](https://overwolf.github.io/api/manifest#manifestjson-without-fields-summary) was not consistent with both the api and with the one with fields summary, on the `enable_top_isolation` setting not being in data. This commit fixes that.
Fell free to edit