### PR TITLE
Add dpiScale to WindowInfo object

### DIFF
--- a/website/pages/docs/api/windows/windows.mdx
+++ b/website/pages/docs/api/windows/windows.mdx
@@ -1043,6 +1043,7 @@ window          | [WindowInfo](#windowinfo-object) object     |             |
 Parameter       | Type          | Description             |
 ----------------| --------------| ----------------------- |
 id              | string        |                         |
+dpiScale        | number        | 1 = 100%, 1.25 = 125%, ... |
 name            | string        |                         |
 width           | number        | with DPI conversion     | 
 height          | number        | with DPI conversion     | 


### PR DESCRIPTION
Calling `overwolf.windows.getCurrentWindow` returns `dpiScale` which is updated based on current scaling.

Example:
```json
{
  "window": {
    "id": "Window_Extension_lbkdbgdijedpnmifplbkcjgbioaklmpghbehfmnp_desktop",
    "name": "desktop",
    "width": 400,
    "height": 660,
    "top": 200,
    "left": 3040,
    "isVisible": true,
    "logicalBounds": {
      "top": 200,
      "left": 3040,
      "width": 400,
      "height": 660
    },
    "state": "Normal",
    "dpiScale": 1,
    "stateEx": "normal",
    "monitorId": "\\\\.\\DISPLAY1",
    "type": "Desktop"
  },
  "status": "success",
  "success": true
}
```

Related to https://github.com/overwolf/types/pull/62