### PR TITLE
Add qa_inside_400x300 to test display ads

### DIFF
--- a/website/pages/docs/start/test-your-app/how-to-test-your-app.mdx
+++ b/website/pages/docs/start/test-your-app/how-to-test-your-app.mdx
@@ -193,6 +193,14 @@ In order to get a 300x250 video test ad enabled on your app, please follow these
 4. Open http://localhost:54284
 5. Open app
 
+In order to get a 400x300 display test ad enabled on your app, please follow these steps:
+
+1. Open app
+2. Paste `localStorage.owAdsForceAdUnit = "qa_inside_400x300"` into the console
+3. Press F5 to refresh window
+4. Open http://localhost:54284
+5. Open app
+
 ### Testing Ad visibility
 
 1. Launch your app.


### PR DESCRIPTION
`localStorage.owAdsForceAdUnit = "qa_inside_400x300"` allows you to create 400x300 display test ads.
I copied the guide from the video test ads (a few lines above).