### PR TITLE
Update media.mdx explaining that getScreenshotUrl currently doesn't work in DX12 games.

### DIFF
--- a/website/pages/docs/api/media/media.mdx
+++ b/website/pages/docs/api/media/media.mdx
@@ -199,6 +199,17 @@ overwolf.media.getScreenshotUrl(
 );
 ```
 
+### Known Issues
+overwolf.media.getScreenshotUrl in any DX12 game always returns the following result:
+```json
+{
+  success: false,
+  status: 'error',
+  error: 'Capture failed'
+}
+```
+This is a known limitation of the current implementation.  There is a workaround using overwolf.media.takeScreenshot and deleting the screenshot afterward but it's less performant.
+
 ## shareImage(image, description, callback)
 #### Version added: 0.78
 


### PR DESCRIPTION
Explain that there is a known issue of getScreenshotUrl not behaving as expected in a DX12 game per https://discord.com/channels/501313732480204808/1121368370323918868

I found this out after posting my own question, but a snippet like this in the docs would have saved me a lot of trial and error: https://discord.com/channels/501313732480204808/1126891837727199254