### PR TITLE
typo in is_victim_teammate

### DIFF
--- a/website/pages/docs/api/games/events/valorant.mdx
+++ b/website/pages/docs/api/games/events/valorant.mdx
@@ -315,7 +315,7 @@ List of parameters:
 * headshot - Boolean value if the kill was by headshot
 * weapon - name of the weapon/ability/ultimate used by the killing player or spike/fall damage
 * is_attacker_teammate - true/false if the attacker is a teammate 
-* is_victime_teammate - true/false if the victime is a teammate 
+* is_victim_teammate - true/false if the victim is a teammate 
 
 <details open>
 <summary>List of available weapons</summary>


### PR DESCRIPTION
I'm not sure if this is just a typo in the docs, or also in the actual parameters, so you may want to double-check that before committing.