### PR TITLE
docs: rename `ow-electron` import to `electron`

### DIFF
--- a/pages/tools/ow-electron/_readme.mdx
+++ b/pages/tools/ow-electron/_readme.mdx
@@ -27,7 +27,7 @@ and when a certain app's window is shown).
 You can disable these analytics with the following piece of code:
 
 ```js
-import { app } from 'ow-electron';
+import { app } from 'electron';
 
 app.overwolf.disableAnonymousAnalytics();
 


### PR DESCRIPTION
In this piece of code it shows we should import `ow-electron` instead of `electron` or `@overwolf/ow-electron`. I changed it to `electron` as `@overwolf/ow-electron` does not export anything, just `module.exports = getElectronPath();`.

Even though this may look like an small issue, it can make people install `ow-electron`, right now it's a dead package, but it's possible that the owner converts it to malware.