### PR TITLE
Move obsolete note to getRunningGameInfo

### DIFF
--- a/pages/api/games/games.mdx
+++ b/pages/api/games/games.mdx
@@ -71,11 +71,11 @@ callback  | [(Result:GetRunningGameInfoResult)](#getrunninggameinforesult-object
 overwolf.games.getRunningGameInfo2(console.log)
 ```
 
+## getRunningGameInfo(callback)
+
 :::warning OBSOLETE
 This function is obsolete - please use `getRunningGameInfo2` instead.
 :::
-
-## getRunningGameInfo(callback)
 
 #### Version added: 0.78 
 


### PR DESCRIPTION
If you go to https://overwolf.github.io/api/games#getrunninggameinfocallback, you won't see the obsolete note, because it's visible above it. I moved the note to make sure, it's under the getRunningGameInfo title.